### PR TITLE
Fix syntax error in package.json

### DIFF
--- a/conferenceOwen/package.json
+++ b/conferenceOwen/package.json
@@ -20,7 +20,7 @@
     "react-native-safe-area-context": "^3.1.1",
     "react-native-screens": "^2.9.0",
     "react-native-tab-view": "^2.15.0",
-    "react-native-vector-icons": "^7.0.0",
+    "react-native-vector-icons": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
 # Fix syntax error in package.json

Erase unnecessary character in the package.json that creates a syntax error 

